### PR TITLE
test: fix test suite isolation

### DIFF
--- a/l1nkzip/cache.py
+++ b/l1nkzip/cache.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import redis.asyncio as redis
 
-from l1nkzip.config import settings
+from l1nkzip import config
 from l1nkzip.logging import get_logger
 
 
@@ -27,9 +27,9 @@ class Cache:
     def _initialize_client(self):
         """Initialize or reinitialize Redis client."""
         self.client = None
-        if settings.redis_server:
+        if config.settings.redis_server:
             try:
-                self.client = redis.from_url(settings.redis_server, decode_responses=True)
+                self.client = redis.from_url(config.settings.redis_server, decode_responses=True)
             except Exception as e:
                 logger.error("Failed to connect to Redis", extra={"error": str(e)})
                 self.client = None
@@ -67,7 +67,7 @@ class Cache:
             return False
 
         try:
-            ttl_value = ttl or settings.redis_ttl
+            ttl_value = ttl or config.settings.redis_ttl
             await self.client.set(key, value, ex=ttl_value)
             return True
         except Exception as e:

--- a/l1nkzip/cache.py
+++ b/l1nkzip/cache.py
@@ -21,18 +21,26 @@ class Cache:
 
     def __init__(self):
         """Initialize Redis client if REDIS_SERVER is configured."""
-        self.client: Optional[redis.Redis] = None
-        self._initialize_client()
+        self._client: Optional[redis.Redis] = None
 
-    def _initialize_client(self):
-        """Initialize or reinitialize Redis client."""
-        self.client = None
-        if config.settings.redis_server:
+    @property
+    def client(self) -> Optional[redis.Redis]:
+        """Get or lazily initialize the Redis client.
+
+        The client is created on first access so that ``config.settings`` is
+        read at runtime rather than at import time, which keeps test patches
+        effective and avoids connection side effects on module import.
+        """
+        if self._client is None and config.settings.redis_server:
             try:
-                self.client = redis.from_url(config.settings.redis_server, decode_responses=True)
+                self._client = redis.from_url(config.settings.redis_server, decode_responses=True)
             except Exception as e:
                 logger.error("Failed to connect to Redis", extra={"error": str(e)})
-                self.client = None
+        return self._client
+
+    @client.setter
+    def client(self, value: Optional[redis.Redis]) -> None:
+        self._client = value
 
     async def get(self, key: str) -> Optional[str]:
         """Get value from cache.

--- a/l1nkzip/mcp.py
+++ b/l1nkzip/mcp.py
@@ -1,4 +1,5 @@
 import asyncio
+import secrets
 
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
@@ -270,7 +271,7 @@ async def _handle_list_urls(arguments: dict) -> list[types.TextContent]:
     except Exception:
         raise ValueError("Unauthorized") from None
 
-    if token != config.settings.token:
+    if not secrets.compare_digest(token, config.settings.token):
         raise ValueError("Unauthorized")
 
     limit = arguments.get("limit", 100)

--- a/l1nkzip/mcp.py
+++ b/l1nkzip/mcp.py
@@ -4,8 +4,8 @@ from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 import mcp.types as types
 
+from l1nkzip import config
 from l1nkzip.cache import cache
-from l1nkzip.config import settings
 from l1nkzip.logging import get_logger
 from l1nkzip.metrics import metrics
 
@@ -103,14 +103,14 @@ async def _handle_shorten_url(arguments: dict) -> list[types.TextContent]:
     except Exception as e:
         raise ValueError(f"Invalid URL: {e}") from e
 
-    if settings.phishtank:
+    if config.settings.phishtank:
         try:
             phish = await retry_phishtank_check(validated_url)
         except Exception as e:
             logger.warning("PhishTank check failed in shorten_url", extra={"error": str(e), "url": validated_url})
             phish = None
         if phish:
-            if settings.metrics_enabled:
+            if config.settings.metrics_enabled:
                 try:
                     metrics.record_phishing_block()
                 except Exception as metric_exc:
@@ -129,13 +129,13 @@ async def _handle_shorten_url(arguments: dict) -> list[types.TextContent]:
     if not link:
         raise ValueError("Failed to create short URL: invalid link data")
 
-    if settings.metrics_enabled:
+    if config.settings.metrics_enabled:
         try:
             metrics.record_url_created()
         except Exception as metric_exc:
             logger.warning("metrics.record_url_created failed", extra={"error": str(metric_exc)})
 
-    api_domain = settings.api_domain
+    api_domain = config.settings.api_domain
     if not api_domain:
         raise ValueError("api_domain is not configured")
     short_url = f"{api_domain.rstrip('/')}/{link}"
@@ -174,14 +174,14 @@ async def _handle_get_original_url(arguments: dict) -> list[types.TextContent]:
             cached_url = await cache.get(f"redirect:{validated_link}")
             if isinstance(cached_url, bytes):
                 cached_url = cached_url.decode()
-            if settings.metrics_enabled:
+            if config.settings.metrics_enabled:
                 metrics.record_cache_operation("get", hit=bool(cached_url))
             if cached_url:
                 original_url = cached_url
                 cache_hit = True
         except Exception as e:
             logger.error("Cache get error in get_original_url", extra={"error": str(e), "link": validated_link})
-            if settings.metrics_enabled:
+            if config.settings.metrics_enabled:
                 try:
                     metrics.record_cache_operation("get", success=False)
                 except Exception as metric_exc:
@@ -208,27 +208,27 @@ async def _handle_get_original_url(arguments: dict) -> list[types.TextContent]:
         if cache.is_enabled():
             try:
                 await cache.set(f"redirect:{validated_link}", original_url)
-                if settings.metrics_enabled:
+                if config.settings.metrics_enabled:
                     metrics.record_cache_operation("set", success=True)
             except Exception as e:
                 logger.error(
                     "Cache set error in get_original_url",
                     extra={"error": str(e), "link": validated_link},
                 )
-                if settings.metrics_enabled:
+                if config.settings.metrics_enabled:
                     try:
                         metrics.record_cache_operation("set", success=False)
                     except Exception as metric_exc:
                         logger.warning("metrics.record_cache_operation failed", extra={"error": str(metric_exc)})
 
-    if settings.phishtank:
+    if config.settings.phishtank:
         try:
             phish = await retry_phishtank_check(original_url)
         except Exception as e:
             logger.warning("PhishTank check failed in get_original_url", extra={"error": str(e), "url": original_url})
             phish = None
         if phish:
-            if settings.metrics_enabled:
+            if config.settings.metrics_enabled:
                 try:
                     metrics.record_phishing_block()
                 except Exception as metric_exc:
@@ -236,7 +236,7 @@ async def _handle_get_original_url(arguments: dict) -> list[types.TextContent]:
             detail = str(getattr(phish, "phish_detail_url", "")) or "https://phishtank.org/"
             raise ValueError(f"URL is flagged as phishing. Details: {detail}")
 
-    if settings.metrics_enabled:
+    if config.settings.metrics_enabled:
         try:
             metrics.record_redirect()
         except Exception as metric_exc:
@@ -270,7 +270,7 @@ async def _handle_list_urls(arguments: dict) -> list[types.TextContent]:
     except Exception:
         raise ValueError("Unauthorized") from None
 
-    if token != settings.token:
+    if token != config.settings.token:
         raise ValueError("Unauthorized")
 
     limit = arguments.get("limit", 100)

--- a/l1nkzip/metrics.py
+++ b/l1nkzip/metrics.py
@@ -15,7 +15,7 @@ from prometheus_client import (
 )
 from prometheus_client.core import CollectorRegistry
 
-from l1nkzip.config import settings
+from l1nkzip import config
 
 
 class MetricsCollector:
@@ -166,7 +166,7 @@ class MetricsCollector:
 
     def is_enabled(self) -> bool:
         """Check if metrics collection is enabled."""
-        return getattr(settings, "metrics_enabled", False)
+        return getattr(config.settings, "metrics_enabled", False)
 
 
 # Global metrics instance

--- a/l1nkzip/models.py
+++ b/l1nkzip/models.py
@@ -6,8 +6,7 @@ from typing import List
 from pony.orm import Database, Optional, PrimaryKey, Required, db_session
 from pydantic import BaseModel, HttpUrl
 
-from l1nkzip import generator
-from l1nkzip.config import settings
+from l1nkzip import config, generator
 
 
 db = Database()
@@ -47,7 +46,7 @@ class Link(db.Entity):  # type: ignore
     @property
     def full_link(self) -> str:
         link_str = str(self.link) if self.link is not None else ""
-        return str(Path(settings.api_domain, link_str))
+        return str(Path(config.settings.api_domain, link_str))
 
 
 class PhishTank(db.Entity):  # type: ignore

--- a/l1nkzip/models.py
+++ b/l1nkzip/models.py
@@ -1,6 +1,5 @@
 import asyncio
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import List
 
 from pony.orm import Database, Optional, PrimaryKey, Required, db_session
@@ -46,7 +45,8 @@ class Link(db.Entity):  # type: ignore
     @property
     def full_link(self) -> str:
         link_str = str(self.link) if self.link is not None else ""
-        return str(Path(config.settings.api_domain, link_str))
+        api_domain = config.settings.api_domain.rstrip("/")
+        return f"{api_domain}/{link_str}"
 
 
 class PhishTank(db.Entity):  # type: ignore

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -1,5 +1,7 @@
 import asyncio
+from contextlib import contextmanager
 import re
+import sys
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -8,14 +10,8 @@ import pytest
 from l1nkzip.config import Settings
 
 
+@contextmanager
 def _get_app():
-    import sys
-
-    modules_to_clear = ["l1nkzip.config", "l1nkzip.models", "l1nkzip.main"]
-    for module in modules_to_clear:
-        if module in sys.modules:
-            del sys.modules[module]
-
     test_settings = Settings()
     test_settings.db_type = "inmemory"
     test_settings.redis_server = None
@@ -24,16 +20,19 @@ def _get_app():
     test_settings.rate_limit_create = "1000/minute"
     test_settings.rate_limit_redirect = "2000/minute"
 
+    # Reload main so it picks up the patched settings at import time.
+    sys.modules.pop("l1nkzip.main", None)
+
     with patch("l1nkzip.config.settings", test_settings):
         from l1nkzip.main import app
 
-    return app
+        yield app
 
 
 @pytest.fixture
 def mcp_test_client():
-    app = _get_app()
-    yield TestClient(app)
+    with _get_app() as app:
+        yield TestClient(app)
 
 
 async def _collect_sse_messages(app, path: str = "/mcp/sse", timeout: float = 2.0):
@@ -146,8 +145,8 @@ class TestMCPModuleImports:
 
 class TestMCPSSEStreamIntegration:
     def test_sse_stream_handshake(self):
-        app = _get_app()
-        messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
+        with _get_app() as app:
+            messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
 
         response_start = next(m for m in messages if m["type"] == "http.response.start")
         assert response_start["status"] == 200
@@ -163,8 +162,8 @@ class TestMCPSSEStreamIntegration:
         assert re.search(session_pattern, full_body), f"No session_id found in: {full_body[:500]}"
 
     def test_sse_stream_has_cache_control(self):
-        app = _get_app()
-        messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
+        with _get_app() as app:
+            messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
 
         response_start = next(m for m in messages if m["type"] == "http.response.start")
         headers_dict = {k.decode(): v.decode() for k, v in response_start["headers"]}
@@ -172,8 +171,8 @@ class TestMCPSSEStreamIntegration:
         assert "no-store" in cache_control or "no-cache" in cache_control
 
     def test_sse_stream_connection_keep_alive(self):
-        app = _get_app()
-        messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
+        with _get_app() as app:
+            messages = asyncio.run(_collect_sse_messages(app, timeout=0.5))
 
         response_start = next(m for m in messages if m["type"] == "http.response.start")
         headers_dict = {k.decode(): v.decode() for k, v in response_start["headers"]}

--- a/tests/api/test_mcp_tools.py
+++ b/tests/api/test_mcp_tools.py
@@ -7,6 +7,7 @@ us to validate behavior without driving the full SSE/JSON-RPC transport.
 """
 
 import asyncio
+from contextlib import contextmanager
 import json
 import logging
 import re
@@ -20,11 +21,6 @@ from l1nkzip.config import Settings
 
 
 def _get_handlers():
-    modules_to_clear = ["l1nkzip.config", "l1nkzip.models", "l1nkzip.main", "l1nkzip.mcp"]
-    for module in modules_to_clear:
-        if module in sys.modules:
-            del sys.modules[module]
-
     test_settings = Settings()
     test_settings.db_type = "inmemory"
     test_settings.redis_server = None
@@ -32,20 +28,20 @@ def _get_handlers():
     test_settings.phishtank = None
     test_settings.rate_limit_create = "1000/minute"
     test_settings.rate_limit_redirect = "2000/minute"
+
+    # Reload main so handlers are wired with the patched settings.
+    sys.modules.pop("l1nkzip.main", None)
+    sys.modules.pop("l1nkzip.mcp", None)
 
     with patch("l1nkzip.config.settings", test_settings):
         from l1nkzip.main import app  # noqa: F401 - imports app to wire mcp handlers
         from l1nkzip.mcp import handle_call_tool, handle_list_tools
 
-    return handle_list_tools, handle_call_tool
+        return handle_list_tools, handle_call_tool
 
 
+@contextmanager
 def _get_app():
-    modules_to_clear = ["l1nkzip.config", "l1nkzip.models", "l1nkzip.main", "l1nkzip.mcp"]
-    for module in modules_to_clear:
-        if module in sys.modules:
-            del sys.modules[module]
-
     test_settings = Settings()
     test_settings.db_type = "inmemory"
     test_settings.redis_server = None
@@ -54,10 +50,12 @@ def _get_app():
     test_settings.rate_limit_create = "1000/minute"
     test_settings.rate_limit_redirect = "2000/minute"
 
+    sys.modules.pop("l1nkzip.main", None)
+
     with patch("l1nkzip.config.settings", test_settings):
         from l1nkzip.main import app
 
-    return app
+        yield app
 
 
 @pytest.fixture
@@ -179,7 +177,7 @@ class TestShortenUrlTool:
             phish_detail_url = "https://phishtank.org/detail/test"
 
         with (
-            patch("l1nkzip.mcp.settings.phishtank", "test-api-key"),
+            patch("l1nkzip.config.settings.phishtank", "test-api-key"),
             patch("l1nkzip.main.retry_phishtank_check") as mock_retry,
         ):
             mock_retry.return_value = FakePhish()
@@ -264,7 +262,7 @@ class TestGetOriginalUrlTool:
         short_link = full_link.replace("https://l1nk.zip/", "")
 
         with (
-            patch("l1nkzip.mcp.settings.phishtank", "test-api-key"),
+            patch("l1nkzip.config.settings.phishtank", "test-api-key"),
             patch("l1nkzip.main.retry_phishtank_check") as mock_retry,
         ):
             mock_retry.return_value = FakePhish()
@@ -288,7 +286,7 @@ def list_urls_handlers(test_settings):
     import l1nkzip.main  # noqa: F401
     from l1nkzip.mcp import handle_call_tool, handle_list_tools
 
-    with patch("l1nkzip.mcp.settings", test_settings):
+    with patch("l1nkzip.config.settings", test_settings):
         yield handle_list_tools, handle_call_tool
 
 
@@ -550,8 +548,8 @@ async def _drive_sse_messages(app, timeout: float = 3.0):
 
 class TestListUrlsSSEIntegration:
     def test_missing_token_returns_error_over_sse(self):
-        app = _get_app()
-        blob = asyncio.run(_drive_sse_messages(app))
+        with _get_app() as app:
+            blob = asyncio.run(_drive_sse_messages(app))
 
         assert '"id": 2' in blob or '"id":2' in blob
         assert '"isError":true' in blob

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Pytest configuration and shared fixtures for L1nkZip tests.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
+from pony.orm import db_session
 from prometheus_client import Counter, Gauge, Histogram
 from prometheus_client.core import CollectorRegistry
 import pytest
@@ -29,20 +30,17 @@ def test_settings():
 @pytest.fixture
 def test_client(test_settings):
     """Test client with in-memory database and test settings."""
-    # Clear modules first to ensure clean import
+    # Reload main so settings captured at import time use the patched values.
     import sys
 
-    modules_to_clear = ["l1nkzip.config", "l1nkzip.models", "l1nkzip.main"]
-    for module in modules_to_clear:
-        if module in sys.modules:
-            del sys.modules[module]
+    for module in ("l1nkzip.main",):
+        sys.modules.pop(module, None)
 
-    # Patch settings before importing
+    # Patch settings for the whole test and import a fresh app instance.
     with patch("l1nkzip.config.settings", test_settings):
-        # Import fresh modules
         from l1nkzip.main import app
 
-        return TestClient(app)
+        yield TestClient(app)
 
 
 @pytest.fixture
@@ -156,21 +154,17 @@ def mock_phishtank():
 @pytest.fixture
 async def async_test_client(test_settings):
     """Async test client for async tests."""
+    import sys
+
+    for module in ("l1nkzip.main",):
+        sys.modules.pop(module, None)
+
     with patch("l1nkzip.config.settings", test_settings):
-        # Clear modules to ensure settings are reloaded
-        import sys
-
-        modules_to_clear = ["l1nkzip.config", "l1nkzip.models", "l1nkzip.main"]
-        for module in modules_to_clear:
-            if module in sys.modules:
-                del sys.modules[module]
-
-        # Import fresh modules
         from fastapi.testclient import TestClient
 
         from l1nkzip.main import app
 
-        return TestClient(app)
+        yield TestClient(app)
 
 
 # Test data fixtures
@@ -215,3 +209,26 @@ def invalid_tokens():
         " ",
         "",
     ]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_test_state():
+    """Reset shared global state after each test to keep tests isolated."""
+    yield
+
+    # Reset the Redis cache client so cache-enabled tests don't leak state.
+    from l1nkzip.cache import cache
+
+    cache.client = None
+
+    # Clear the in-memory database tables.
+    from l1nkzip.models import Link, PhishTank
+
+    try:
+        with db_session:
+            Link.select().delete(bulk=True)
+            PhishTank.select().delete(bulk=True)
+    except Exception:
+        # If the DB is not bound (e.g. unit tests that never import main),
+        # there is nothing to clean up.
+        pass

--- a/tests/integration/test_creation_flow.py
+++ b/tests/integration/test_creation_flow.py
@@ -79,24 +79,13 @@ class TestCreationFlow:
     def test_creation_with_caching(self, test_client, mock_redis, metrics_collector):
         """Test URL creation flow with Redis caching."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
-            # Clear modules to ensure settings are reloaded
-            import sys
-
-            modules_to_clear = ["l1nkzip.config", "l1nkzip.cache"]
-            for module in modules_to_clear:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Import fresh modules
-            from l1nkzip.main import app
-
-            # Create new test client with Redis enabled
-            redis_client = TestClient(app)
-
-            # Import cache module and set mock client after initialization
             from l1nkzip.cache import cache
 
             cache.client = mock_redis
+
+            from l1nkzip.main import app
+
+            redis_client = TestClient(app)
 
             # Create URL
             response = redis_client.post("/url", json={"url": "https://example.com"})

--- a/tests/integration/test_redirect_flow.py
+++ b/tests/integration/test_redirect_flow.py
@@ -55,24 +55,13 @@ class TestRedirectFlow:
     def test_redirect_flow_with_caching(self, test_client, mock_redis, metrics_collector):
         """Test redirect flow with Redis caching."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
-            # Clear modules to ensure settings are reloaded
-            import sys
-
-            modules_to_clear = ["l1nkzip.config", "l1nkzip.cache"]
-            for module in modules_to_clear:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Import fresh modules
-            from l1nkzip.main import app
-
-            # Create new test client with Redis enabled
-            redis_client = TestClient(app)
-
-            # Import cache module and set mock client after initialization
             from l1nkzip.cache import cache
 
             cache.client = mock_redis
+
+            from l1nkzip.main import app
+
+            redis_client = TestClient(app)
 
             # Create a URL first
             create_response = redis_client.post("/url", json={"url": "https://example.com"})
@@ -334,24 +323,13 @@ class TestRedirectFlow:
     def test_redirect_flow_cache_eviction(self, test_client, mock_redis, metrics_collector):
         """Test redirect flow with cache eviction scenarios."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
-            # Clear modules to ensure settings are reloaded
-            import sys
-
-            modules_to_clear = ["l1nkzip.config", "l1nkzip.cache"]
-            for module in modules_to_clear:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Import fresh modules
-            from l1nkzip.main import app
-
-            # Create new test client with Redis enabled
-            redis_client = TestClient(app)
-
-            # Import cache module and set mock client after initialization
             from l1nkzip.cache import cache
 
             cache.client = mock_redis
+
+            from l1nkzip.main import app
+
+            redis_client = TestClient(app)
 
             # Create a URL first
             create_response = redis_client.post("/url", json={"url": "https://example.com"})
@@ -381,24 +359,13 @@ class TestRedirectFlow:
     def test_redirect_flow_comprehensive(self, test_client, metrics_collector, mock_redis):
         """Test comprehensive redirect flow with all components."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
-            # Clear modules to ensure settings are reloaded
-            import sys
-
-            modules_to_clear = ["l1nkzip.config", "l1nkzip.cache"]
-            for module in modules_to_clear:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Import fresh modules
-            from l1nkzip.main import app
-
-            # Create new test client with Redis enabled
-            redis_client = TestClient(app)
-
-            # Import cache module and set mock client after initialization
             from l1nkzip.cache import cache
 
             cache.client = mock_redis
+
+            from l1nkzip.main import app
+
+            redis_client = TestClient(app)
 
             # Create a URL first
             create_response = redis_client.post("/url", json={"url": "https://example.com"})

--- a/tests/unit/test_caching.py
+++ b/tests/unit/test_caching.py
@@ -49,34 +49,37 @@ class TestCache:
     async def test_get_with_enabled_cache(self):
         """Test get operation with enabled cache."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
+            mock_client = AsyncMock()
+            mock_client.get.return_value = "cached_value"
             test_cache = Cache()
-            test_cache.client = AsyncMock()
-            test_cache.client.get.return_value = "cached_value"
+            test_cache.client = mock_client
 
             result = await test_cache.get("test_key")
             assert result == "cached_value"
-            test_cache.client.get.assert_called_once_with("test_key")
+            mock_client.get.assert_called_once_with("test_key")
 
     @pytest.mark.asyncio
     async def test_set_with_enabled_cache(self):
         """Test set operation with enabled cache."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
             with patch("l1nkzip.config.settings.redis_ttl", 3600):
+                mock_client = AsyncMock()
+                mock_client.set.return_value = True
                 test_cache = Cache()
-                test_cache.client = AsyncMock()
-                test_cache.client.set.return_value = True
+                test_cache.client = mock_client
 
                 result = await test_cache.set("test_key", "test_value")
                 assert result is True
-                test_cache.client.set.assert_called_once_with("test_key", "test_value", ex=3600)
+                mock_client.set.assert_called_once_with("test_key", "test_value", ex=3600)
 
     @pytest.mark.asyncio
     async def test_get_handles_exceptions(self):
         """Test that get handles Redis exceptions gracefully."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = Exception("Redis error")
             test_cache = Cache()
-            test_cache.client = AsyncMock()
-            test_cache.client.get.side_effect = Exception("Redis error")
+            test_cache.client = mock_client
 
             result = await test_cache.get("test_key")
             assert result is None
@@ -85,9 +88,10 @@ class TestCache:
     async def test_set_handles_exceptions(self):
         """Test that set handles Redis exceptions gracefully."""
         with patch("l1nkzip.config.settings.redis_server", "redis://localhost:6379/0"):
+            mock_client = AsyncMock()
+            mock_client.set.side_effect = Exception("Redis error")
             test_cache = Cache()
-            test_cache.client = AsyncMock()
-            test_cache.client.set.side_effect = Exception("Redis error")
+            test_cache.client = mock_client
 
             result = await test_cache.set("test_key", "test_value")
             assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "l1nkzip"
-version = "0.5.10"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Make pytest deterministic across all test directories.

- Read config.settings lazily in cache, metrics, models and mcp.

- Keep settings patch active during fixtures and only reload main.

- Reset cache client and DB tables between tests.

- Update MCP and integration helpers to avoid stale module references.
